### PR TITLE
Change to prior predictive to fit context.

### DIFF
--- a/principled_bayesian_workflow/principled_bayesian_workflow.Rmd
+++ b/principled_bayesian_workflow/principled_bayesian_workflow.Rmd
@@ -316,7 +316,7 @@ $$
 t(\tilde{y})
 $$
 yields samples from the pushforward of the prior predictive distribution.  We
-can then histogram these samples to implement the posterior predictive check.
+can then histogram these samples to implement the prior predictive check.
 
 <br><br>
 ![](figures/prior_predictive/prior_predictive_practice/prior_predictive_practice.png)

--- a/principled_bayesian_workflow/principled_bayesian_workflow.Rmd
+++ b/principled_bayesian_workflow/principled_bayesian_workflow.Rmd
@@ -267,7 +267,7 @@ observations that are considered extreme within the scope of our domain
 expertise then indicates conflict between the modeling assumptions and that 
 domain expertise.
 
-Analyzing the posterior predictive distribution, however, is not particularly
+Analyzing the prior predictive distribution, however, is not particularly
 straightforward when the observation space is high-dimensional.  In this case 
 we have to consider _summary statistics_ that project the observational space to 
 some lower dimensional space that's more amenable to visualization, and hence 


### PR DESCRIPTION
Based on the surrounding context, I am pretty sure you meant **prior** predictive instead of **posterior** predictive.  Thanks for such great materials, they are much appreciated!