### PR TITLE
Typo fix? (ordinal regression)

### DIFF
--- a/ordinal_regression/ordinal_regression.Rmd
+++ b/ordinal_regression/ordinal_regression.Rmd
@@ -93,7 +93,7 @@ In practice we can compute these probabilities as differences between the
 complementary cumulative distribution function,
 $$
 \Pi_{c}(x) 
-= \int_{-\infty}^{x} \mathrm{d} x \, \pi_{c}(x)
+= \int_{-\infty}^{-x} \mathrm{d} x \, \pi_{c}(x)
 = \int_{x}^{\infty} \mathrm{d} x \, \pi(x),
 $$
 evaluated at the cut points,


### PR DESCRIPTION
I might have got confused, but it seems the limit of integration should be -x as opposed to x.